### PR TITLE
Anaconda environment problem solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
             "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "objective-c": "cd $dir && gcc -framework Cocoa $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "php": "php",
-            "python": "python -u",
+            "python": "$pythonPath -u $fullFileName",
             "perl": "perl",
             "perl6": "perl6",
             "ruby": "ruby",


### PR DESCRIPTION
https://stackoverflow.com/questions/51930833/vs-code-not-running-a-python-file-in-the-conda-environment-mentioned/67878090#67878090

When we create an environment in anaconda and select this environment in the editor, coderunner uses base environment. My change fixes this problem.